### PR TITLE
Upgrade Quill Dependency to 2.0.0-rc.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,9 +43,8 @@
     "LICENSE"
   ],
   "dependencies": {
-    "@types/quill": "^1.3.10",
-    "lodash": "^4.17.4",
-    "quill": "^1.3.7"
+    "lodash": "^4.17.21",
+    "quill": "^2.0.0-rc.4"
   },
   "peerDependencies": {
     "react": "^16 || ^17 || ^18",
@@ -70,6 +69,7 @@
     "jsdom-global": "^3.0.2",
     "mocha": "^6.2.2",
     "mocha-text-cov": "^0.1.1",
+    "quill-delta": "^5.1.0",
     "react": "^16.11.0",
     "react-dom": "^16.11.0",
     "react-test-renderer": "^16.11.0",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -185,7 +185,7 @@ class ReactQuill extends React.Component<ReactQuillProps, ReactQuillState> {
   validateProps(props: ReactQuillProps): void {
     if (React.Children.count(props.children) > 1) throw new Error(
       'The Quill editing area can only be composed of a single React element.'
-      );
+    );
 
     if (React.Children.count(props.children)) {
       const child = React.Children.only(props.children);
@@ -199,8 +199,8 @@ class ReactQuill extends React.Component<ReactQuillProps, ReactQuillState> {
       props.value === this.lastDeltaChangeSet
       ) throw new Error(
         'You are passing the `delta` object from the `onChange` event back ' +
-          'as `value`. You most probably want `editor.getContents()` instead. ' +
-          'See: https://github.com/zenoamaro/react-quill#using-deltas'
+        'as `value`. You most probably want `editor.getContents()` instead. ' +
+        'See: https://github.com/zenoamaro/react-quill#using-deltas'
       );
   }
 
@@ -519,8 +519,8 @@ class ReactQuill extends React.Component<ReactQuillProps, ReactQuillState> {
     // We keep storing the same type of value as what the user gives us,
     // so that value comparisons will be more stable and predictable.
     const nextContents = this.isDelta(this.value)
-    ? editor.getContents()
-    : editor.getHTML();
+      ? editor.getContents()
+      : editor.getHTML();
 
     if (nextContents !== this.getEditorContents()) {
       // Taint this `delta` object, so we can recognize whether the user

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -197,11 +197,11 @@ class ReactQuill extends React.Component<ReactQuillProps, ReactQuillState> {
     if (
       this.lastDeltaChangeSet &&
       props.value === this.lastDeltaChangeSet
-      ) throw new Error(
-        'You are passing the `delta` object from the `onChange` event back ' +
-        'as `value`. You most probably want `editor.getContents()` instead. ' +
-        'See: https://github.com/zenoamaro/react-quill#using-deltas'
-      );
+    ) throw new Error(
+      'You are passing the `delta` object from the `onChange` event back ' +
+      'as `value`. You most probably want `editor.getContents()` instead. ' +
+      'See: https://github.com/zenoamaro/react-quill#using-deltas'
+    );
   }
 
   shouldComponentUpdate(nextProps: ReactQuillProps, nextState: ReactQuillState) {


### PR DESCRIPTION
This PR updates the `quill` dependency in `react-quill` from an outdated version (1.3.7) to the latest release candidate, 2.0.0-rc.4. The previous major version of Quill has not been updated for over five years and includes several security vulnerabilities that have been resolved in version 2.0.

<img width="586" alt="Screenshot 2024-04-04 at 15 15 46" src="https://github.com/zenoamaro/react-quill/assets/43890857/40cf458f-499d-4ec6-a1cf-24371531fb29">


### Key Changes

- **Version Upgrade**: 
The upgrade to Quill 2.0.0-rc.4 addresses critical security concerns, ensuring a safer and more reliable library for our users.
- **Enhanced Security**: The new version includes patches for vulnerabilities identified in the earlier releases, significantly improving the overall security posture of applications using react-quill.
- **Future-Proofing**:
By staying current with Quill's latest versions, we ensure compatibility with future updates and maintain the robustness of react-quill.